### PR TITLE
Add close button email component

### DIFF
--- a/src/components/Email/EmailComponent.jsx
+++ b/src/components/Email/EmailComponent.jsx
@@ -9,7 +9,7 @@ import LoadingComponent from '../LoadingComponent/LoadingComponent';
 
 const DEFAULT_TRANSLATION = {
     cancel: 'Cancel',
-    close: 'Close',
+    close: 'Ok',
     error: 'Error',
     loading: 'Registering subscription',
     placeholder: 'Enter Email address',

--- a/src/components/Email/EmailComponent.jsx
+++ b/src/components/Email/EmailComponent.jsx
@@ -23,7 +23,7 @@ const DEFAULT_TRANSLATION = {
 const DEFAULT_STYLES = {
     actionsContainer: `
         display: flex;
-        justify-content: flex-end;
+        justify-content: flex-start;
     `,
     emailInput: `
         width: 100%; 

--- a/src/components/Email/EmailComponent.jsx
+++ b/src/components/Email/EmailComponent.jsx
@@ -208,7 +208,9 @@ export default class EmailComponent extends React.Component {
 
 
         let body = null;
-        let formActions = null;//(<Cancel type='button' onClick={this.handleCancel}>{this.translation.close}</Cancel>);
+        let formActions = this.state.statusMessage === this.translation.registerSuccess ? 
+            (<Submit type='button' onClick={this.handleCancel}>{this.translation.close}</Submit>) : 
+            null;
         
         if (! this.state.hasSubmitted) {
             body = this._renderFormBody();


### PR DESCRIPTION
## Issue number
ensdomains/ens-app#1162 
## Description
Email reminder confirmation modal should have an 'OK' button. Improves UX by adding another way for users to exit modal window than clicking outside of the modal. The close button was initially removed: [ensdomains/ens-app/pull/776](https://github.com/ensdomains/ens-app/pull/776#issuecomment-634255730)
## List of features added/changed
- Add close button to BUIDLHub email notification modal on Address & Name pages when email subscription has been registered
- Minor styling update for integration 
## How Has This Been Tested?
Existing unit tests run on static build + manual testing
![Jest test suites](https://user-images.githubusercontent.com/53792888/137160480-57ab92de-fba2-447a-8019-7bba20704516.png)
## Screenshots (if appropriate):
- **Before:**
![after screenshot desktop](https://user-images.githubusercontent.com/53792888/137162699-7c10c8a8-3012-4e5e-85d1-bf6010d23db3.png)
![after screenshot mobile](https://user-images.githubusercontent.com/53792888/137163842-d722b8f2-793b-4a32-8aeb-a4b2b9901cab.png)
- **After:**
![after screenshot desktop](https://user-images.githubusercontent.com/53792888/137162418-c9b8bb50-6dbb-428f-8f4b-5c95e4dd09df.png)
![after screenshot mobile](https://user-images.githubusercontent.com/53792888/137163625-8626fcd7-674c-4ac7-ab5f-83137616c8ca.png)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.